### PR TITLE
feat(notify): add Feishu and WeCom formats for HTTP webhook

### DIFF
--- a/internal/app/handler/settings/handler.go
+++ b/internal/app/handler/settings/handler.go
@@ -213,6 +213,7 @@ func filterChannelValue(name string, channel ChannelValues) ChannelValues {
 	case "http":
 		values.Endpoint = channel.Endpoint
 		values.Headers = channel.Headers
+		values.Format = channel.Format
 	case "email":
 		values.SMTPHost = channel.SMTPHost
 		values.SMTPPort = channel.SMTPPort
@@ -247,6 +248,7 @@ func channelSettingsFromValues(name string, channel ChannelValues) appsettings.C
 	case "http":
 		normalized.Endpoint = channel.Endpoint
 		normalized.Headers = normalizeHeaders(channel.Headers)
+		normalized.Format = channel.Format
 	case "email":
 		normalized.SMTPHost = channel.SMTPHost
 		normalized.SMTPPort = channel.SMTPPort
@@ -290,6 +292,7 @@ func channelSettingsValues(name string, channel appsettings.Channel) ChannelValu
 	case "http":
 		values.Endpoint = channel.Endpoint
 		values.Headers = cloneHeaders(channel.Headers)
+		values.Format = channel.Format
 	case "email":
 		values.SMTPHost = channel.SMTPHost
 		values.SMTPPort = channel.SMTPPort

--- a/internal/app/handler/settings/schema.go
+++ b/internal/app/handler/settings/schema.go
@@ -83,6 +83,11 @@ func settingsSchema() Schema {
 						Description: "settings.schema.channels.http.headers.description",
 						Control:     controlKeyValue,
 					},
+					selectField("format", "settings.schema.channels.http.format.label", "settings.schema.channels.http.format.description", false, []Option{
+						{Label: "settings.schema.channels.http.format.options.raw", Value: "raw"},
+						{Label: "settings.schema.channels.http.format.options.feishu", Value: "feishu"},
+						{Label: "settings.schema.channels.http.format.options.wecom", Value: "wecom"},
+					}),
 				},
 			},
 			{

--- a/internal/app/handler/settings/types.go
+++ b/internal/app/handler/settings/types.go
@@ -32,6 +32,7 @@ type ChannelValues struct {
 	Recipients []string `json:"recipients,omitempty" validate:"omitempty,dive,required"`
 
 	Headers map[string]string `json:"headers,omitempty" validate:"omitempty,dive,keys,required,endkeys"`
+	Format  string            `json:"format,omitempty" validate:"omitempty,oneof=raw feishu wecom"`
 
 	SMTPHost     string `json:"smtpHost,omitempty"`
 	SMTPPort     int    `json:"smtpPort,omitempty" validate:"omitempty,gte=1,lte=65535"`

--- a/internal/pkg/notify/webhook/webhook.go
+++ b/internal/pkg/notify/webhook/webhook.go
@@ -20,6 +20,7 @@ type Sender struct {
 	client   *http.Client
 	endpoint string
 	headers  map[string]string
+	format   string
 }
 
 func New(channel *settings.Channel) (*Sender, error) {
@@ -35,19 +36,14 @@ func New(channel *settings.Channel) (*Sender, error) {
 		client:   &http.Client{Timeout: 10 * time.Second},
 		endpoint: parsed.String(),
 		headers:  channel.Headers,
+		format:   strings.ToLower(strings.TrimSpace(channel.Format)),
 	}, nil
 }
 
 func (s *Sender) Send(ctx context.Context, ev notifyevent.Event) error {
-	body, err := json.Marshal(struct {
-		Kind    notifyevent.Kind  `json:"kind"`
-		Payload notifyevent.Event `json:"payload"`
-	}{
-		Kind:    ev.Kind(),
-		Payload: ev,
-	})
+	body, err := s.body(ev)
 	if err != nil {
-		return fmt.Errorf("encoding http event: %w", err)
+		return err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -67,4 +63,48 @@ func (s *Sender) Send(ctx context.Context, ev notifyevent.Event) error {
 		return fmt.Errorf("http response status %s: %s", resp.Status, strings.TrimSpace(string(responseBody)))
 	}
 	return nil
+}
+
+// body builds the request payload. Feishu and WeCom share a simple text message
+// shape (only the field names differ); any other format sends the default
+// {kind, payload} document.
+func (s *Sender) body(ev notifyevent.Event) ([]byte, error) {
+	switch s.format {
+	case "feishu":
+		return json.Marshal(map[string]any{
+			"msg_type": "text",
+			"content":  map[string]string{"text": renderText(ev)},
+		})
+	case "wecom":
+		return json.Marshal(map[string]any{
+			"msgtype": "text",
+			"text":    map[string]string{"content": renderText(ev)},
+		})
+	default:
+		return json.Marshal(struct {
+			Kind    notifyevent.Kind  `json:"kind"`
+			Payload notifyevent.Event `json:"payload"`
+		}{
+			Kind:    ev.Kind(),
+			Payload: ev,
+		})
+	}
+}
+
+func renderText(ev notifyevent.Event) string {
+	switch ev := ev.(type) {
+	case notifyevent.OTPEvent:
+		return fmt.Sprintf("Sigmo Login\nYour verification code is %s", strings.TrimSpace(ev.Code))
+	case notifyevent.SMSEvent:
+		return fmt.Sprintf("%s\n%s", ev.DisplayCounterparty(), ev.DisplayText())
+	case notifyevent.CallEvent:
+		number := ev.DisplayCounterparty()
+		title := ev.DirectionLabel()
+		if number != "" {
+			title = fmt.Sprintf("%s from %s", title, number)
+		}
+		return fmt.Sprintf("%s\nModem: %s\nTime: %s", title, strings.TrimSpace(ev.Modem), ev.DisplayTimestamp())
+	default:
+		return ""
+	}
 }

--- a/internal/pkg/settings/settings.go
+++ b/internal/pkg/settings/settings.go
@@ -34,6 +34,7 @@ type Channel struct {
 
 	// HTTP
 	Headers map[string]string `json:"headers,omitempty"`
+	Format  string            `json:"format,omitempty"`
 
 	// Email
 	SMTPHost     string `json:"smtpHost,omitempty"`

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -140,6 +140,16 @@ const en = {
             label: 'Headers',
             description: 'Optional HTTP headers.',
           },
+          format: {
+            label: 'Message format',
+            description:
+              'Default sends the raw JSON event; Feishu or WeCom sends the matching text message format.',
+            options: {
+              raw: 'Default (raw JSON)',
+              feishu: 'Feishu',
+              wecom: 'WeCom',
+            },
+          },
         },
         email: {
           label: 'Email',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -140,6 +140,15 @@ const zh = {
             label: 'Headers',
             description: '可选 HTTP 请求头。',
           },
+          format: {
+            label: '消息格式',
+            description: '默认发送原始 JSON 事件；选择飞书或企业微信将发送对应的文本消息格式。',
+            options: {
+              raw: '默认（原始 JSON）',
+              feishu: '飞书',
+              wecom: '企业微信',
+            },
+          },
         },
         email: {
           label: 'Email',

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -16,6 +16,7 @@ export type SettingsChannel = {
   botToken?: string
   recipients?: string[]
   headers?: Record<string, string>
+  format?: string
   smtpHost?: string
   smtpPort?: number
   smtpUsername?: string


### PR DESCRIPTION
## Summary
- Add a message format selector to the HTTP webhook notification channel (default raw JSON, Feishu text, WeCom text).
- Render OTP, SMS, and call notifications into plain text for Feishu/WeCom bot payloads while preserving the existing default webhook JSON shape.

## Test plan
- [ ] Open Settings → HTTP Webhook and verify the new format dropdown appears (Default / Feishu / WeCom).
- [ ] Save with format set to Feishu, trigger an SMS notification, and confirm the bot receives `{"msg_type":"text","content":{"text":"..."}}`.
- [ ] Save with format set to WeCom, trigger an SMS notification, and confirm the bot receives `{"msgtype":"text","text":{"content":"..."}}`.
- [ ] Leave format as Default and confirm webhook payloads still use `{kind, payload}` JSON.