### PR TITLE
feat(notify): add Lark and WeCom notification channels

### DIFF
--- a/internal/app/handler/settings/handler.go
+++ b/internal/app/handler/settings/handler.go
@@ -210,6 +210,10 @@ func filterChannelValue(name string, channel ChannelValues) ChannelValues {
 		values.Priority = channel.Priority
 	case "sc3":
 		values.Endpoint = channel.Endpoint
+	case "lark":
+		values.Endpoint = channel.Endpoint
+	case "wecom":
+		values.Endpoint = channel.Endpoint
 	case "http":
 		values.Endpoint = channel.Endpoint
 		values.Headers = channel.Headers
@@ -243,6 +247,10 @@ func channelSettingsFromValues(name string, channel ChannelValues) appsettings.C
 		normalized.Recipients = normalizeRecipients(channel.Recipients)
 		normalized.Priority = channel.Priority
 	case "sc3":
+		normalized.Endpoint = channel.Endpoint
+	case "lark":
+		normalized.Endpoint = channel.Endpoint
+	case "wecom":
 		normalized.Endpoint = channel.Endpoint
 	case "http":
 		normalized.Endpoint = channel.Endpoint
@@ -286,6 +294,10 @@ func channelSettingsValues(name string, channel appsettings.Channel) ChannelValu
 		values.Recipients = channel.Recipients.Strings()
 		values.Priority = channel.Priority
 	case "sc3":
+		values.Endpoint = channel.Endpoint
+	case "lark":
+		values.Endpoint = channel.Endpoint
+	case "wecom":
 		values.Endpoint = channel.Endpoint
 	case "http":
 		values.Endpoint = channel.Endpoint

--- a/internal/app/handler/settings/schema.go
+++ b/internal/app/handler/settings/schema.go
@@ -72,6 +72,22 @@ func settingsSchema() Schema {
 				},
 			},
 			{
+				Key:         "lark",
+				Label:       "settings.schema.channels.lark.label",
+				Description: "settings.schema.channels.lark.description",
+				Fields: []Field{
+					textField("endpoint", "settings.schema.channels.lark.endpoint.label", "settings.schema.channels.lark.endpoint.description", "settings.schema.channels.lark.endpoint.placeholder", true),
+				},
+			},
+			{
+				Key:         "wecom",
+				Label:       "settings.schema.channels.wecom.label",
+				Description: "settings.schema.channels.wecom.description",
+				Fields: []Field{
+					textField("endpoint", "settings.schema.channels.wecom.endpoint.label", "settings.schema.channels.wecom.endpoint.description", "settings.schema.channels.wecom.endpoint.placeholder", true),
+				},
+			},
+			{
 				Key:         "http",
 				Label:       "settings.schema.channels.http.label",
 				Description: "settings.schema.channels.http.description",

--- a/internal/pkg/notify/lark/render.go
+++ b/internal/pkg/notify/lark/render.go
@@ -1,0 +1,30 @@
+package lark
+
+import (
+	"fmt"
+	"strings"
+
+	notifyevent "github.com/damonto/sigmo/internal/pkg/notify/event"
+)
+
+func render(ev notifyevent.Event) (string, error) {
+	switch ev := ev.(type) {
+	case notifyevent.OTPEvent:
+		code := strings.TrimSpace(ev.Code)
+		return fmt.Sprintf("Sigmo Login\nYour verification code is %s", code), nil
+	case notifyevent.SMSEvent:
+		return fmt.Sprintf("%s\n%s", ev.DisplayCounterparty(), ev.DisplayText()), nil
+	case notifyevent.CallEvent:
+		return fmt.Sprintf("%s\nModem: %s\nTime: %s", callTitle(ev), strings.TrimSpace(ev.Modem), ev.DisplayTimestamp()), nil
+	default:
+		return "", fmt.Errorf("rendering lark content for %q: unsupported event", ev.Kind())
+	}
+}
+
+func callTitle(ev notifyevent.CallEvent) string {
+	number := ev.DisplayCounterparty()
+	if number == "" {
+		return ev.DirectionLabel()
+	}
+	return fmt.Sprintf("%s from %s", ev.DirectionLabel(), number)
+}

--- a/internal/pkg/notify/lark/sender.go
+++ b/internal/pkg/notify/lark/sender.go
@@ -1,0 +1,75 @@
+package lark
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	notifyevent "github.com/damonto/sigmo/internal/pkg/notify/event"
+	"github.com/damonto/sigmo/internal/pkg/settings"
+)
+
+type Sender struct {
+	client   *http.Client
+	endpoint string
+}
+
+type message struct {
+	MsgType string  `json:"msg_type"`
+	Content content `json:"content"`
+}
+
+type content struct {
+	Text string `json:"text"`
+}
+
+func New(channel *settings.Channel) (*Sender, error) {
+	endpoint := strings.TrimSpace(channel.Endpoint)
+	if endpoint == "" {
+		return nil, errors.New("lark endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parsing lark endpoint: %w", err)
+	}
+	return &Sender{
+		client:   &http.Client{Timeout: 10 * time.Second},
+		endpoint: parsed.String(),
+	}, nil
+}
+
+func (s *Sender) Send(ctx context.Context, ev notifyevent.Event) error {
+	text, err := render(ev)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(message{MsgType: "text", Content: content{Text: text}})
+	if err != nil {
+		return fmt.Errorf("encoding lark message: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building lark request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending lark message: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("lark response status %s: %s", resp.Status, strings.TrimSpace(string(responseBody)))
+	}
+	return nil
+}

--- a/internal/pkg/notify/notify.go
+++ b/internal/pkg/notify/notify.go
@@ -13,9 +13,11 @@ import (
 	notifyemail "github.com/damonto/sigmo/internal/pkg/notify/email"
 	notifyevent "github.com/damonto/sigmo/internal/pkg/notify/event"
 	notifygotify "github.com/damonto/sigmo/internal/pkg/notify/gotify"
+	notifylark "github.com/damonto/sigmo/internal/pkg/notify/lark"
 	notifysc3 "github.com/damonto/sigmo/internal/pkg/notify/sc3"
 	notifytelegram "github.com/damonto/sigmo/internal/pkg/notify/telegram"
 	notifywebhook "github.com/damonto/sigmo/internal/pkg/notify/webhook"
+	notifywecom "github.com/damonto/sigmo/internal/pkg/notify/wecom"
 	"github.com/damonto/sigmo/internal/pkg/settings"
 )
 
@@ -60,6 +62,10 @@ func createSender(name string, channel settings.Channel) (Sender, error) {
 		return notifygotify.New(&channel)
 	case "sc3":
 		return notifysc3.New(&channel)
+	case "lark":
+		return notifylark.New(&channel)
+	case "wecom":
+		return notifywecom.New(&channel)
 	default:
 		return nil, fmt.Errorf("unsupported channel type: %s", name)
 	}

--- a/internal/pkg/notify/wecom/render.go
+++ b/internal/pkg/notify/wecom/render.go
@@ -1,0 +1,30 @@
+package wecom
+
+import (
+	"fmt"
+	"strings"
+
+	notifyevent "github.com/damonto/sigmo/internal/pkg/notify/event"
+)
+
+func render(ev notifyevent.Event) (string, error) {
+	switch ev := ev.(type) {
+	case notifyevent.OTPEvent:
+		code := strings.TrimSpace(ev.Code)
+		return fmt.Sprintf("Sigmo Login\nYour verification code is %s", code), nil
+	case notifyevent.SMSEvent:
+		return fmt.Sprintf("%s\n%s", ev.DisplayCounterparty(), ev.DisplayText()), nil
+	case notifyevent.CallEvent:
+		return fmt.Sprintf("%s\nModem: %s\nTime: %s", callTitle(ev), strings.TrimSpace(ev.Modem), ev.DisplayTimestamp()), nil
+	default:
+		return "", fmt.Errorf("rendering wecom content for %q: unsupported event", ev.Kind())
+	}
+}
+
+func callTitle(ev notifyevent.CallEvent) string {
+	number := ev.DisplayCounterparty()
+	if number == "" {
+		return ev.DirectionLabel()
+	}
+	return fmt.Sprintf("%s from %s", ev.DirectionLabel(), number)
+}

--- a/internal/pkg/notify/wecom/sender.go
+++ b/internal/pkg/notify/wecom/sender.go
@@ -1,0 +1,75 @@
+package wecom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	notifyevent "github.com/damonto/sigmo/internal/pkg/notify/event"
+	"github.com/damonto/sigmo/internal/pkg/settings"
+)
+
+type Sender struct {
+	client   *http.Client
+	endpoint string
+}
+
+type message struct {
+	MsgType string `json:"msgtype"`
+	Text    text   `json:"text"`
+}
+
+type text struct {
+	Content string `json:"content"`
+}
+
+func New(channel *settings.Channel) (*Sender, error) {
+	endpoint := strings.TrimSpace(channel.Endpoint)
+	if endpoint == "" {
+		return nil, errors.New("wecom endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parsing wecom endpoint: %w", err)
+	}
+	return &Sender{
+		client:   &http.Client{Timeout: 10 * time.Second},
+		endpoint: parsed.String(),
+	}, nil
+}
+
+func (s *Sender) Send(ctx context.Context, ev notifyevent.Event) error {
+	body, err := render(ev)
+	if err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(message{MsgType: "text", Text: text{Content: body}})
+	if err != nil {
+		return fmt.Errorf("encoding wecom message: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("building wecom request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending wecom message: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("wecom response status %s: %s", resp.Status, strings.TrimSpace(string(responseBody)))
+	}
+	return nil
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -128,6 +128,24 @@ const en = {
             placeholder: 'https://uid.push.ft07.com/send/key.send',
           },
         },
+        lark: {
+          label: 'Lark',
+          description: 'Send notifications to a Lark custom bot.',
+          endpoint: {
+            label: 'Webhook',
+            description: 'Lark custom bot webhook URL.',
+            placeholder: 'https://open.feishu.cn/open-apis/bot/v2/hook/xxxx',
+          },
+        },
+        wecom: {
+          label: 'WeCom',
+          description: 'Send notifications to a WeCom group bot.',
+          endpoint: {
+            label: 'Webhook',
+            description: 'WeCom group bot webhook URL.',
+            placeholder: 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxx',
+          },
+        },
         http: {
           label: 'HTTP webhook',
           description: 'POST notification events to a custom webhook.',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -128,6 +128,24 @@ const zh = {
             placeholder: 'https://uid.push.ft07.com/send/key.send',
           },
         },
+        lark: {
+          label: 'Lark',
+          description: '发送通知到飞书自定义机器人。',
+          endpoint: {
+            label: 'Webhook',
+            description: '飞书自定义机器人的 Webhook 地址。',
+            placeholder: 'https://open.feishu.cn/open-apis/bot/v2/hook/xxxx',
+          },
+        },
+        wecom: {
+          label: 'WeCom',
+          description: '发送通知到企业微信群机器人。',
+          endpoint: {
+            label: 'Webhook',
+            description: '企业微信群机器人的 Webhook 地址。',
+            placeholder: 'https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxx',
+          },
+        },
         http: {
           label: 'HTTP Webhook',
           description: '将通知事件 POST 到自定义 webhook。',


### PR DESCRIPTION
## Summary
- Add dedicated Lark (Feishu) and WeCom notification channels with platform-specific text webhook payloads.
- Follow the existing sc3-style sender pattern: one package per channel, endpoint-only settings schema, and shared event rendering for OTP/SMS/call notifications.
- Add settings UI labels and i18n strings (Lark / WeCom) in English and Chinese.

## Test plan
- [x] Enable Lark channel with a valid Feishu bot webhook and verify OTP/SMS/call notifications arrive as text messages.
- [x] Enable WeCom channel with a valid group bot webhook and verify OTP/SMS/call notifications arrive as text messages.
- [x] Confirm settings page shows Lark and WeCom options with webhook URL field only.
- [x] Run \go build .\ and \go vet ./internal/pkg/notify/...\

Made with [Cursor](https://cursor.com)